### PR TITLE
Färgfixar

### DIFF
--- a/docs/2-visuell-identitet/1-färger.config.js
+++ b/docs/2-visuell-identitet/1-färger.config.js
@@ -138,6 +138,11 @@ module.exports = {
             name: 'Felmeddelande',
             hex: '#CD2126',
             variable: '$color-framework-red'
+          },
+          {
+            name: 'Konfirmeringsmeddelande',
+            hex: '#1D9A18',
+            variable: '$color-framework-green'
           }
         ]
       },

--- a/src/ui/components/section-heading/section-heading.scss
+++ b/src/ui/components/section-heading/section-heading.scss
@@ -11,7 +11,7 @@
     max-width: 100%;
     height: 3px;
     margin: 1em 0 0 0;
-    background: $color-background-red-lighter;
+    background: $color-complement-purple-light;
   }
 
   @include media-max('md') {

--- a/src/ui/containers/news/news.scss
+++ b/src/ui/containers/news/news.scss
@@ -24,7 +24,7 @@
 
   &__list-item {
     padding: .5em 0;
-    border-bottom: 1px solid $color-gray-border;
+    border-bottom: 1px solid $color-complement-purple-light;
 
     &:last-child {
       border-bottom: none;

--- a/src/ui/core/scss/variables/colors.scss
+++ b/src/ui/core/scss/variables/colors.scss
@@ -24,6 +24,7 @@ $color-complement-purple-light: #f8f4f8;
 
 $color-framework-blue: #0079c2;
 $color-framework-red: #cd2126;
+$color-framework-green: #ad9a18;
 
 $color-gray-background: #f2f2f2;
 $color-gray-border: #d9d9d9;


### PR DESCRIPTION
- Lägg till den nya gröna färgen (#ad9a18)
- Använd `$color-complement-purple-light` som ram i nyhetslistan och sektionstitel