### PR TITLE
Fix - HTML preview not rendering sometimes

### DIFF
--- a/theme/views/partials/browser/panel-notes.nunj
+++ b/theme/views/partials/browser/panel-notes.nunj
@@ -1,0 +1,9 @@
+<div class="Browser-panel Browser-notes" data-role="tab-panel" id="browser-{{ entity.id }}-panel-notes">
+    <div class="Prose Prose--condensed">
+        {% if entity.notes %}
+        {{ frctl.docs.renderString(entity.notes, null, renderEnv) | async }}
+        {% else %}
+        <p class="Browser-isEmptyNote">There are no notes for this item.</p>
+        {% endif %}
+    </div>
+</div>


### PR DESCRIPTION
Fixed issue where Mandelbrot would not render html preview if there was a readme.md present in the component folder and when the view used fractals render function